### PR TITLE
Adds empty payload to delete request to prevent error from Localytics.

### DIFF
--- a/lib/localytics.rb
+++ b/lib/localytics.rb
@@ -38,8 +38,10 @@ module Localytics
       raise Error.new('No API secret provided')
     end
 
-    payload = JSON.generate(params) if method == :post || method == :patch
-    params = nil unless method == :get
+    unless method == :get
+      payload = JSON.generate(params)
+      params = nil
+    end
 
     auth = 'Basic ' + Base64.strict_encode64("#{api_key}:#{api_secret}")
 


### PR DESCRIPTION
When using the `Localytics.Profile.delete` method I was receiving the error:
```
For request 'DELETE /v1/profiles/48314' [Invalid Json]
```

This change builds and empty hash payload to send with the request, and returns a successful response.